### PR TITLE
Add .gitignore for site, Python cache and OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Build output
+site/
+
+# Editor configuration
+.vscode/
+
+# Python cache and compiled files
+__pycache__/
+*.pyc
+
+# OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add `.gitignore` with entries for build output, editor files, Python caches and OS artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841874530e48325a917ceaad30a1f0b