### PR TITLE
Add ArgoCD deployment manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim AS build
+WORKDIR /app
+COPY . .
+RUN pip install mkdocs-material && mkdocs build --clean
+
+FROM nginx:alpine
+COPY --from=build /app/site /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/kubernetes/argocd.md
+++ b/docs/kubernetes/argocd.md
@@ -1,0 +1,27 @@
+# Déployer OnlyDocs avec ArgoCD et Traefik
+
+Cette page explique comment mettre en place le site avec ArgoCD et l'ingress controller Traefik.
+
+## Image Docker
+
+Construisez l'image contenant le site puis poussez-la vers un registre :
+
+```bash
+docker build -t ghcr.io/theonlymore/onlydocs:latest .
+docker push ghcr.io/theonlymore/onlydocs:latest
+```
+
+## Installation d'ArgoCD et de Traefik
+
+Installez ArgoCD sur votre cluster Kubernetes puis déployez Traefik en tant qu'ingress controller.
+
+## Déploiement du site
+
+Les manifestes Kubernetes se trouvent dans le dossier `k8s/` de ce dépôt.
+Créez l'application ArgoCD avec :
+
+```bash
+kubectl apply -f k8s/argocd-app.yaml
+```
+
+ArgoCD appliquera ensuite le `Deployment`, le `Service` et l'`Ingress` pour exposer le site via Traefik.

--- a/k8s/argocd-app.yaml
+++ b/k8s/argocd-app.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: onlydocs
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Theonlymore/OnlyDocs.git
+    targetRevision: HEAD
+    path: k8s
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onlydocs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: onlydocs
+  template:
+    metadata:
+      labels:
+        app: onlydocs
+    spec:
+      containers:
+      - name: onlydocs
+        image: ghcr.io/theonlymore/onlydocs:latest
+        ports:
+        - containerPort: 80

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: onlydocs
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+  - host: docs.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: onlydocs
+            port:
+              number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: onlydocs
+spec:
+  selector:
+    app: onlydocs
+  ports:
+  - port: 80
+    targetPort: 80

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - volumes: kubernetes/volumes.md
       - manifest: kubernetes/manifest.md
       - exemple: kubernetes/exemple.md
+      - ArgoCD: kubernetes/argocd.md
   - Ansible: 
       - Présentation Ansible: ansible/ansiblePresentation.md
       - Base d'Ansible: ansible/ansibleBase.md


### PR DESCRIPTION
## Summary
- containerize the docs with a Dockerfile
- add Kubernetes manifests using Traefik
- provide an ArgoCD application definition
- document how to deploy with ArgoCD
- link the new docs in mkdocs config

## Testing
- `pip install mkdocs-material`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6841e4dfc13c83258b056721de51f1b3