### PR TITLE
Build Docker image via ArgoCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OnlyDocs
 
-## Pourquoi 
+## Pourquoi
 
 Cela me permet de noter facilement les choses.
 
 ## Comment
 
-### Outil 
+### Outil
 
 MkDocs est un outil en Python qui me permet de convertir mes fichiers Markdown en fichiers web (HTML, CSS, ...)
 
@@ -40,5 +40,22 @@ Coût final
 
 Pour payer le moins cher possible, il faudrait passer par un autre acteur qu'AWS pour le nom de domaine.
 
+## Construire l'image Docker
 
+Ce dépôt contient un `Dockerfile` vous permettant de créer l'image Docker du site sans utiliser d'image préconstruite. Après avoir cloné ce dépôt :
 
+```bash
+# Cloner le code depuis GitHub
+git clone https://github.com/Theonlymore/OnlyDocs.git
+cd OnlyDocs
+
+# Construire l'image
+docker build -t onlydocs:latest .
+
+# (Optionnel) lancer le conteneur localement
+docker run -p 8080:80 onlydocs:latest
+```
+
+Vous obtenez ainsi une image construite à partir du code source présent sur GitHub uniquement.
+Si vous déployez via ArgoCD, le Job `k8s/build-image-job.yaml` s'occupe
+également de construire cette image avant de lancer le site.

--- a/docs/kubernetes/argocd.md
+++ b/docs/kubernetes/argocd.md
@@ -2,14 +2,15 @@
 
 Cette page explique comment mettre en place le site avec ArgoCD et l'ingress controller Traefik.
 
-## Image Docker
+## Construction de l'image
 
-Construisez l'image contenant le site puis poussez-la vers un registre :
+ArgoCD peut construire l'image directement depuis ce dépôt grâce au fichier
+`k8s/build-image-job.yaml`. Ce Job utilise Kaniko pour créer l'image et la
+pousser dans un registre interne `registry.default.svc.cluster.local:5000`.
 
-```bash
-docker build -t ghcr.io/theonlymore/onlydocs:latest .
-docker push ghcr.io/theonlymore/onlydocs:latest
-```
+Le Job s'exécute en phase **PreSync** puis le `Deployment` démarre le conteneur
+à partir de l'image fraîchement construite lorsque vous appliquez
+`k8s/argocd-app.yaml`.
 
 ## Installation d'ArgoCD et de Traefik
 

--- a/k8s/build-image-job.yaml
+++ b/k8s/build-image-job.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: build-onlydocs
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: kaniko
+        image: gcr.io/kaniko-project/executor:latest
+        args:
+        - "--dockerfile=Dockerfile"
+        - "--context=git://github.com/Theonlymore/OnlyDocs.git"
+        - "--destination=registry.default.svc.cluster.local:5000/onlydocs:latest"
+        - "--insecure"
+        - "--skip-tls-verify"
+

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: onlydocs
-        image: ghcr.io/theonlymore/onlydocs:latest
+        image: registry.default.svc.cluster.local:5000/onlydocs:latest
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Summary
- add Job manifest that builds the Docker image with Kaniko
- update deployment to use the registry built image
- document automated image build with ArgoCD

## Testing
- `mkdocs build --clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6fcf3c08325a2c89a8d61e0296f