### PR TITLE
Add GitHub Container Registry workflow

### DIFF
--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -1,0 +1,31 @@
+name: push-to-ghcr
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+


### PR DESCRIPTION
## Summary
- add a workflow to build the Docker image and push it to GitHub Container Registry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ef28fda8832584d51fe027209d2e